### PR TITLE
게시글 소개 로직 변경으로 인한 코드 수정

### DIFF
--- a/src/main/java/com/server/Puzzle/domain/board/domain/Board.java
+++ b/src/main/java/com/server/Puzzle/domain/board/domain/Board.java
@@ -35,6 +35,9 @@ public class Board extends BaseTimeEntity {
     @Column(name = "board_status", nullable = false)
     private Status status;
 
+    @Column(name = "board_introduce", nullable = false)
+    private String introduce;
+
     @OneToMany(
             mappedBy = "board",
             cascade = CascadeType.REMOVE,
@@ -77,6 +80,10 @@ public class Board extends BaseTimeEntity {
         return this;
     }
 
+    public void updateIntroduce(String introduce){
+        this.introduce = introduce != null ? introduce : this.introduce;
+    }
+
     public Board updatePurpose(Purpose purpose) {
         this.purpose = purpose;
         return this;
@@ -92,10 +99,6 @@ public class Board extends BaseTimeEntity {
                 .anyMatch(b -> b.getUser().equals(currentUser));
     }
 
-    public boolean isAuthor(User currentUser){
-        return this.getUser().equals(currentUser);
-    }
-
     public void updateAttendStatus(Long attendId, AttendStatus attendStatus){
         this.getAttends().stream()
                 .filter(a ->
@@ -106,4 +109,7 @@ public class Board extends BaseTimeEntity {
                 .updateAttendStatus(attendStatus);
     }
 
+    public boolean isAuthor(User currentUser){
+        return this.getUser().equals(currentUser);
+    }
 }

--- a/src/main/java/com/server/Puzzle/domain/board/dto/request/CorrectionPostRequestDto.java
+++ b/src/main/java/com/server/Puzzle/domain/board/dto/request/CorrectionPostRequestDto.java
@@ -18,6 +18,7 @@ public class CorrectionPostRequestDto {
     private String contents;
     private Purpose purpose;
     private Status status;
+    private String introduce;
     private List<String> fileUrlList;
     private List<Field> fieldList;
     private List<Language> languageList;

--- a/src/main/java/com/server/Puzzle/domain/board/dto/request/PostRequestDto.java
+++ b/src/main/java/com/server/Puzzle/domain/board/dto/request/PostRequestDto.java
@@ -1,7 +1,9 @@
 package com.server.Puzzle.domain.board.dto.request;
 
+import com.server.Puzzle.domain.board.domain.Board;
 import com.server.Puzzle.domain.board.enumType.Purpose;
 import com.server.Puzzle.domain.board.enumType.Status;
+import com.server.Puzzle.domain.user.domain.User;
 import com.server.Puzzle.global.enumType.Field;
 import com.server.Puzzle.global.enumType.Language;
 import lombok.*;
@@ -23,5 +25,15 @@ public class PostRequestDto {
     private List<Language> languageList;
     private List<String> fileUrlList;
 
+    public Board dtoToEntity(User user){
+        return Board.builder()
+                .title(this.getTitle())
+                .contents(this.getContents())
+                .purpose(this.getPurpose())
+                .status(this.getStatus())
+                .user(user)
+                .introduce(this.getIntroduce())
+                .build();
+    }
 }
 

--- a/src/main/java/com/server/Puzzle/domain/board/dto/request/PostRequestDto.java
+++ b/src/main/java/com/server/Puzzle/domain/board/dto/request/PostRequestDto.java
@@ -18,6 +18,7 @@ public class PostRequestDto {
     private String contents;
     private Purpose purpose;
     private Status status;
+    private String introduce;
     private List<Field> fieldList;
     private List<Language> languageList;
     private List<String> fileUrlList;

--- a/src/main/java/com/server/Puzzle/domain/board/dto/response/GetAllPostResponseDto.java
+++ b/src/main/java/com/server/Puzzle/domain/board/dto/response/GetAllPostResponseDto.java
@@ -15,5 +15,6 @@ public class GetAllPostResponseDto {
     private Status status;
     private LocalDateTime createDateTime;
     private String image_url;
+    private String introduce;
 
 }

--- a/src/main/java/com/server/Puzzle/domain/board/dto/response/GetPostByTagResponseDto.java
+++ b/src/main/java/com/server/Puzzle/domain/board/dto/response/GetPostByTagResponseDto.java
@@ -16,5 +16,6 @@ public class GetPostByTagResponseDto {
     private Status status;
     private LocalDateTime createdDate;
     private String fileUrl;
+    private String introduce;
 
 }

--- a/src/main/java/com/server/Puzzle/domain/board/dto/response/GetPostResponseDto.java
+++ b/src/main/java/com/server/Puzzle/domain/board/dto/response/GetPostResponseDto.java
@@ -22,6 +22,7 @@ public class GetPostResponseDto {
     private Status status;
     private String name;
     private String githubId;
+    private String introduce;
     private LocalDateTime createdAt;
     private List<Field> fields;
     private List<Language> languages;

--- a/src/main/java/com/server/Puzzle/domain/board/repository/BoardCustomRepositoryImpl.java
+++ b/src/main/java/com/server/Puzzle/domain/board/repository/BoardCustomRepositoryImpl.java
@@ -117,6 +117,7 @@ public class BoardCustomRepositoryImpl implements BoardCustomRepository{
                         b.getTitle(),
                         b.getStatus(),
                         b.getCreatedDate(),
+                        b.getIntroduce(),
                         b.getBoardFiles().stream()
                                 .map(f -> f.getUrl())
                                 .findFirst().orElse(null)

--- a/src/main/java/com/server/Puzzle/domain/board/repository/BoardCustomRepositoryImpl.java
+++ b/src/main/java/com/server/Puzzle/domain/board/repository/BoardCustomRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.server.Puzzle.domain.board.repository;
 import com.querydsl.core.QueryResults;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.server.Puzzle.domain.board.domain.Board;
+import com.server.Puzzle.domain.board.domain.BoardFile;
 import com.server.Puzzle.domain.board.dto.response.GetPostByTagResponseDto;
 import com.server.Puzzle.domain.board.enumType.Purpose;
 import com.server.Puzzle.domain.board.enumType.Status;
@@ -32,13 +33,11 @@ public class BoardCustomRepositoryImpl implements BoardCustomRepository{
         HashSet<Long> boardIdHashSet = new HashSet<>();
 
         if (field.get(0) == Field.ALL){
-            List<Long> dbresult = jpaQueryFactory.from(boardField)
+            List<Long> dbResult = jpaQueryFactory.from(boardField)
                     .select(boardField.board.id)
                     .fetch();
 
-            for (Long aLong : dbresult) {
-                boardIdHashSet.add(aLong);
-            }
+            boardIdHashSet.addAll(dbResult);
         } else {
             for (Field f : field) {
                 String name = f.name();
@@ -49,22 +48,18 @@ public class BoardCustomRepositoryImpl implements BoardCustomRepository{
                             .where(boardField.field.eq(Field.valueOf(name.substring(0,name.length() - 4))))
                             .fetch();
 
-                    for (Long aLong : dbresult) {
-                        boardIdHashSet.add(aLong);
-                    }
+                    boardIdHashSet.addAll(dbresult);
                 }
             }
         }
 
         for (Language l : language) {
-            List<Long> dbresult = jpaQueryFactory.from(boardLanguage)
+            List<Long> dbREsult = jpaQueryFactory.from(boardLanguage)
                     .select(boardLanguage.board.id)
                     .where(boardLanguage.language.eq(l))
                     .fetch();
 
-            for (Long aLong : dbresult) {
-                boardIdHashSet.add(aLong);
-            }
+            boardIdHashSet.addAll(dbREsult);
         }
 
         QueryResults<Board> results;
@@ -112,17 +107,18 @@ public class BoardCustomRepositoryImpl implements BoardCustomRepository{
         }
 
         List<GetPostByTagResponseDto> content = results.getResults().stream()
-                .map(b -> new GetPostByTagResponseDto(
-                        b.getId(),
-                        b.getTitle(),
-                        b.getStatus(),
-                        b.getCreatedDate(),
-                        b.getIntroduce(),
-                        b.getBoardFiles().stream()
-                                .map(f -> f.getUrl())
-                                .findFirst().orElse(null)
-                ))
-                .collect(Collectors.toList());
+                .map(
+                        b -> GetPostByTagResponseDto.builder()
+                                .boardId(b.getId())
+                                .title(b.getTitle())
+                                .status(b.getStatus())
+                                .createdDate(b.getCreatedDate())
+                                .introduce(b.getIntroduce())
+                                .fileUrl(b.getBoardFiles().stream()
+                                            .map(BoardFile::getUrl)
+                                            .findFirst().orElse(null))
+                        .build()
+                ).collect(Collectors.toList());
 
         return new PageImpl<>(content, pageable, results.getTotal());
     }

--- a/src/main/java/com/server/Puzzle/domain/board/service/Impl/BoardServiceImpl.java
+++ b/src/main/java/com/server/Puzzle/domain/board/service/Impl/BoardServiceImpl.java
@@ -150,7 +150,7 @@ public class BoardServiceImpl implements BoardService {
 
         List<String> saveFileUrlList = this.getSaveFileUrlList(board, request);
 
-        try{
+        if(saveFileUrlList == Collections.EMPTY_LIST){
             for (String fileUrl : saveFileUrlList) {
                 boardFileRepository.save(
                         BoardFile.builder()
@@ -159,8 +159,6 @@ public class BoardServiceImpl implements BoardService {
                                 .build()
                 );
             }
-        } catch (NullPointerException e){
-            return board;
         }
 
         return board;
@@ -223,7 +221,7 @@ public class BoardServiceImpl implements BoardService {
         Board board = boardRepository.findById(id)
                 .orElseThrow(() -> new CustomException(BOARD_NOT_FOUND));
 
-        if(board.getUser() == currentUserUtil.getCurrentUser()){
+        if(board.isAuthor(currentUserUtil.getCurrentUser())){
             List<BoardFile> boardFiles = board.getBoardFiles();
             for (BoardFile boardFile : boardFiles) {
                 awsS3Util.deleteS3(boardFile.getUrl().substring(61));
@@ -253,7 +251,7 @@ public class BoardServiceImpl implements BoardService {
                 }
                 return addFileList;
             } else {
-                return null;
+                return Collections.EMPTY_LIST;
             }
         } else { // db에 url 이 있다면,
             if(CollectionUtils.isEmpty(requestFileUrlList)){ // 요청파일 목록에 파일이 없다면,
@@ -282,7 +280,7 @@ public class BoardServiceImpl implements BoardService {
             }
         }
 
-        return null;
+        return Collections.EMPTY_LIST;
     }
 
 }

--- a/src/main/java/com/server/Puzzle/domain/board/service/Impl/BoardServiceImpl.java
+++ b/src/main/java/com/server/Puzzle/domain/board/service/Impl/BoardServiceImpl.java
@@ -170,7 +170,7 @@ public class BoardServiceImpl implements BoardService {
 
     @Override
     public Page<GetAllPostResponseDto> getAllPost(Pageable pageable) {
-        Page<GetAllPostResponseDto> response = boardRepository.findAll(pageable).map(
+        return boardRepository.findAll(pageable).map(
                 board -> GetAllPostResponseDto.builder()
                         .boardId(board.getId())
                         .title(board.getTitle())
@@ -181,16 +181,13 @@ public class BoardServiceImpl implements BoardService {
                                         .map(BoardFile::getUrl)
                                         .findFirst().orElse(null)
                         )
-                        .introduce(board.getIntroduce())
                         .build()
         );
-
-        return response;
     }
 
     @Override
     public GetPostResponseDto getPost(Long id) {
-        GetPostResponseDto response = boardRepository.findById(id).map(
+        return boardRepository.findById(id).map(
                 board -> GetPostResponseDto.builder()
                         .id(id)
                         .title(board.getTitle())
@@ -218,8 +215,6 @@ public class BoardServiceImpl implements BoardService {
                         )
                         .build()
         ).orElseThrow(() -> new CustomException(BOARD_NOT_FOUND));
-
-        return response;
     }
 
     @Override
@@ -240,9 +235,7 @@ public class BoardServiceImpl implements BoardService {
 
     @Override
     public Page<GetPostByTagResponseDto> getPostByTag(Purpose purpose, List<Field> field, List<Language> language, Status status, Pageable pageable) {
-        Page<GetPostByTagResponseDto> response = boardRepository.findBoardByTag(purpose, field, language, status, pageable);
-
-        return response;
+        return boardRepository.findBoardByTag(purpose, field, language, status, pageable);
     }
 
     private List<String> getSaveFileUrlList(Board board, CorrectionPostRequestDto request){

--- a/src/main/java/com/server/Puzzle/domain/board/service/Impl/BoardServiceImpl.java
+++ b/src/main/java/com/server/Puzzle/domain/board/service/Impl/BoardServiceImpl.java
@@ -16,7 +16,6 @@ import com.server.Puzzle.domain.board.repository.BoardFileRepository;
 import com.server.Puzzle.domain.board.repository.BoardLanguageRepository;
 import com.server.Puzzle.domain.board.repository.BoardRepository;
 import com.server.Puzzle.domain.board.service.BoardService;
-import com.server.Puzzle.domain.user.domain.User;
 import com.server.Puzzle.global.enumType.Field;
 import com.server.Puzzle.global.enumType.Language;
 import com.server.Puzzle.global.exception.CustomException;
@@ -53,54 +52,16 @@ public class BoardServiceImpl implements BoardService {
 
     @Override
     public void post(PostRequestDto request) {
-        String title = request.getTitle();
-        String contents = request.getContents();
-        Purpose purpose = request.getPurpose();
-        Status status = request.getStatus();
-        String introduce = request.getIntroduce();
-        List<Field> fieldList = request.getFieldList();
-        List<Language> languageList = request.getLanguageList();
-        List<String> fileUrlList = request.getFileUrlList();
-        User currentUser = currentUserUtil.getCurrentUser();
-
         Board board = boardRepository.save(
-                Board.builder()
-                        .title(title)
-                        .contents(contents)
-                        .purpose(purpose)
-                        .status(status)
-                        .user(currentUser)
-                        .introduce(introduce)
-                        .build()
+                request.dtoToEntity(currentUserUtil.getCurrentUser())
         );
 
-        for (String fileUrl : fileUrlList) {
-            boardFileRepository.save(
-                    BoardFile.builder()
-                            .board(board)
-                            .url(fileUrl)
-                            .build()
-            );
-        }
-
-        for (Field field : fieldList) {
-            boardFieldRepository.save(
-                    BoardField.builder()
-                            .board(board)
-                            .field(field)
-                            .build()
-            );
-        }
-
-        for (Language language : languageList) {
-            boardLanguageRepository.save(
-                    BoardLanguage.builder()
-                            .board(board)
-                            .language(language)
-                            .build()
-            );
-        }
+        saveFiledUrls(request.getFileUrlList(), board);
+        saveFileds(request.getFieldList(), board);
+        saveLanguages(request.getLanguageList(), board);
     }
+
+
 
     @Override
     public String createUrl(MultipartFile files) {
@@ -112,58 +73,26 @@ public class BoardServiceImpl implements BoardService {
     @Transactional
     @Override
     public Board correctionPost(Long id, CorrectionPostRequestDto request) {
-        String title = request.getTitle();
-        String contents = request.getContents();
-        Purpose purpose = request.getPurpose();
-        Status status = request.getStatus();
-        String introduce = request.getIntroduce();
-        List<Field> fieldList = request.getFieldList();
-        List<Language> languageList = request.getLanguageList();
-
         Board board = boardRepository.findById(id)
                 .orElseThrow(() -> new CustomException(BOARD_NOT_FOUND));
         if(!board.isAuthor(currentUserUtil.getCurrentUser())) throw new CustomException(BOARD_NOT_HAVE_PERMISSION);
 
         board
-                .updateTitle(title)
-                .updateContents(contents)
-                .updatePurpose(purpose)
-                .updateStatus(status)
-                .updateIntroduce(introduce);
+                .updateTitle(request.getTitle())
+                .updateContents(request.getContents())
+                .updatePurpose(request.getPurpose())
+                .updateStatus(request.getStatus())
+                .updateIntroduce(request.getIntroduce());
 
         boardFieldRepository.deleteByBoardId(board.getId());
         boardLanguageRepository.deleteByBoardId(board.getId());
 
-        for (Field field : fieldList) {
-            boardFieldRepository.save(
-                    BoardField.builder()
-                            .board(board)
-                            .field(field)
-                            .build()
-            );
-        }
-
-        for (Language language : languageList) {
-            boardLanguageRepository.save(
-                    BoardLanguage.builder()
-                            .board(board)
-                            .language(language)
-                            .build()
-            );
-        }
+        saveFileds(request.getFieldList(), board);
+        saveLanguages(request.getLanguageList(), board);
 
         List<String> saveFileUrlList = this.getSaveFileUrlList(board, request);
 
-        if(saveFileUrlList == Collections.EMPTY_LIST){
-            for (String fileUrl : saveFileUrlList) {
-                boardFileRepository.save(
-                        BoardFile.builder()
-                                .board(board)
-                                .url(fileUrl)
-                                .build()
-                );
-            }
-        }
+        if(saveFileUrlList == Collections.EMPTY_LIST) saveFiledUrls(saveFileUrlList, board);
 
         return board;
     }
@@ -224,9 +153,7 @@ public class BoardServiceImpl implements BoardService {
 
         if(board.isAuthor(currentUserUtil.getCurrentUser())){
             List<BoardFile> boardFiles = board.getBoardFiles();
-            for (BoardFile boardFile : boardFiles) {
-                awsS3Util.deleteS3(boardFile.getUrl().substring(61));
-            }
+            for (BoardFile boardFile : boardFiles) awsS3Util.deleteS3(boardFile.getUrl().substring(61));
             boardRepository.deleteById(id);
         } else {
             throw new CustomException(BOARD_NOT_HAVE_PERMISSION);
@@ -236,6 +163,39 @@ public class BoardServiceImpl implements BoardService {
     @Override
     public Page<GetPostByTagResponseDto> getPostByTag(Purpose purpose, List<Field> field, List<Language> language, Status status, Pageable pageable) {
         return boardRepository.findBoardByTag(purpose, field, language, status, pageable);
+    }
+
+    private void saveFiledUrls(List<String> fileUrlList, Board board) {
+        for (String fileUrl : fileUrlList) {
+            boardFileRepository.save(
+                    BoardFile.builder()
+                            .board(board)
+                            .url(fileUrl)
+                            .build()
+            );
+        }
+    }
+
+    private void saveLanguages(List<Language> languageList, Board board) {
+        for (Language language : languageList) {
+            boardLanguageRepository.save(
+                    BoardLanguage.builder()
+                            .board(board)
+                            .language(language)
+                            .build()
+            );
+        }
+    }
+
+    private void saveFileds(List<Field> fieldList, Board board) {
+        for (Field field : fieldList) {
+            boardFieldRepository.save(
+                    BoardField.builder()
+                            .board(board)
+                            .field(field)
+                            .build()
+            );
+        }
     }
 
     private List<String> getSaveFileUrlList(Board board, CorrectionPostRequestDto request){

--- a/src/main/java/com/server/Puzzle/domain/board/service/Impl/BoardServiceImpl.java
+++ b/src/main/java/com/server/Puzzle/domain/board/service/Impl/BoardServiceImpl.java
@@ -57,6 +57,7 @@ public class BoardServiceImpl implements BoardService {
         String contents = request.getContents();
         Purpose purpose = request.getPurpose();
         Status status = request.getStatus();
+        String introduce = request.getIntroduce();
         List<Field> fieldList = request.getFieldList();
         List<Language> languageList = request.getLanguageList();
         List<String> fileUrlList = request.getFileUrlList();
@@ -69,6 +70,7 @@ public class BoardServiceImpl implements BoardService {
                         .purpose(purpose)
                         .status(status)
                         .user(currentUser)
+                        .introduce(introduce)
                         .build()
         );
 
@@ -114,6 +116,7 @@ public class BoardServiceImpl implements BoardService {
         String contents = request.getContents();
         Purpose purpose = request.getPurpose();
         Status status = request.getStatus();
+        String introduce = request.getIntroduce();
         List<Field> fieldList = request.getFieldList();
         List<Language> languageList = request.getLanguageList();
 
@@ -125,7 +128,8 @@ public class BoardServiceImpl implements BoardService {
                 .updateTitle(title)
                 .updateContents(contents)
                 .updatePurpose(purpose)
-                .updateStatus(status);
+                .updateStatus(status)
+                .updateIntroduce(introduce);
 
         boardFieldRepository.deleteByBoardId(board.getId());
         boardLanguageRepository.deleteByBoardId(board.getId());
@@ -174,9 +178,10 @@ public class BoardServiceImpl implements BoardService {
                         .createDateTime(board.getCreatedDate())
                         .image_url(
                                 board.getBoardFiles().stream()
-                                        .map(boardFile -> boardFile.getUrl())
+                                        .map(BoardFile::getUrl)
                                         .findFirst().orElse(null)
                         )
+                        .introduce(board.getIntroduce())
                         .build()
         );
 
@@ -195,19 +200,20 @@ public class BoardServiceImpl implements BoardService {
                         .name(board.getUser().getName())
                         .githubId(board.getUser().getGithubId())
                         .createdAt(board.getCreatedDate())
+                        .introduce(board.getIntroduce())
                         .fields(
                                 board.getBoardFields().stream()
-                                .map(boardField -> boardField.getField())
+                                .map(BoardField::getField)
                                 .collect(Collectors.toList())
                         )
                         .languages(
                                 board.getBoardLanguages().stream()
-                                .map(boardLanguage -> boardLanguage.getLanguage())
+                                .map(BoardLanguage::getLanguage)
                                 .collect(Collectors.toList())
                         )
                         .files(
                                 board.getBoardFiles().stream()
-                                .map(boardFile -> boardFile.getUrl())
+                                .map(BoardFile::getUrl)
                                 .collect(Collectors.toList())
                         )
                         .build()

--- a/src/test/java/com/server/Puzzle/exception/board/BoardExceptionTest.java
+++ b/src/test/java/com/server/Puzzle/exception/board/BoardExceptionTest.java
@@ -27,8 +27,6 @@ import javax.transaction.Transactional;
 import java.util.Collections;
 import java.util.List;
 
-import static com.server.Puzzle.global.exception.ErrorCode.BOARD_NOT_FOUND;
-import static com.server.Puzzle.global.exception.ErrorCode.BOARD_NOT_HAVE_PERMISSION;
 import static org.junit.jupiter.api.Assertions.*;
 
 @Transactional
@@ -46,6 +44,17 @@ public class BoardExceptionTest {
 
     @Autowired
     private CurrentUserUtil currentUserUtil;
+
+    final PostRequestDto postRequestDto = PostRequestDto.builder()
+            .title("title")
+            .contents("contents")
+            .purpose(Purpose.PROJECT)
+            .status(Status.RECRUITMENT)
+            .introduce("this is board")
+            .fieldList(List.of(Field.BACKEND,Field.FRONTEND))
+            .languageList(List.of(Language.JAVA,Language.TS))
+            .fileUrlList(List.of("https://springbootpuzzletest.s3.ap-northeast-2.amazonaws.com/23752bbd-cd6e-4bde-986d-542df0517933.png"))
+            .build();
 
     @BeforeEach
     void 로그인_되어있는_유저를_확인() {
@@ -80,21 +89,12 @@ public class BoardExceptionTest {
     @Test
     void correctionPost_에서_게시글을_찾을_수_없습니다(){
         // given
-        PostRequestDto postRequestDto = PostRequestDto.builder()
-                .title("title")
-                .contents("contents")
-                .purpose(Purpose.PROJECT)
-                .status(Status.RECRUITMENT)
-                .fieldList(List.of(Field.BACKEND,Field.FRONTEND))
-                .languageList(List.of(Language.JAVA,Language.TS))
-                .fileUrlList(List.of("https://springbootpuzzletest.s3.ap-northeast-2.amazonaws.com/23752bbd-cd6e-4bde-986d-542df0517933.png"))
-                .build();
-
         CorrectionPostRequestDto correctionPostRequestDto = CorrectionPostRequestDto.builder()
                 .title("correctionTitle")
                 .contents("correctionContents")
                 .purpose(Purpose.PROJECT)
                 .status(Status.RECRUITMENT)
+                .introduce("this is board")
                 .fileUrlList(List.of("https://springbootpuzzletest.s3.ap-northeast-2.amazonaws.com/23752bbd-cd6e-4bde-986d-542df0517933.png"))
                 .languageList(List.of(Language.PYTORCH, Language.KOTLIN))
                 .fieldList(List.of(Field.AI,Field.ANDROID))
@@ -105,7 +105,7 @@ public class BoardExceptionTest {
         Long boardId = boardRepository.findAll().get(0).getId() + 1L;
 
         // when // then
-        CustomException customException = assertThrows(new CustomException(BOARD_NOT_FOUND).getClass(), () -> {
+        CustomException customException = assertThrows(CustomException.class, () -> {
             boardService.correctionPost(boardId, correctionPostRequestDto);
         });
 
@@ -115,22 +115,12 @@ public class BoardExceptionTest {
     @Test
     void getPost_에서_게시글을_찾을_수_없습니다(){
         // given
-        PostRequestDto postRequestDto = PostRequestDto.builder()
-                .title("title")
-                .contents("contents")
-                .purpose(Purpose.PROJECT)
-                .status(Status.RECRUITMENT)
-                .fieldList(List.of(Field.BACKEND,Field.FRONTEND))
-                .languageList(List.of(Language.JAVA,Language.TS))
-                .fileUrlList(List.of("https://springbootpuzzletest.s3.ap-northeast-2.amazonaws.com/23752bbd-cd6e-4bde-986d-542df0517933.png"))
-                .build();
-
         boardService.post(postRequestDto);
 
         Long boardId = boardRepository.findAll().get(0).getId() + 1L;
 
         // when // then
-        CustomException customException = assertThrows(new CustomException(BOARD_NOT_FOUND).getClass(), () -> {
+        CustomException customException = assertThrows(CustomException.class, () -> {
             boardService.getPost(boardId);
         });
 
@@ -140,22 +130,12 @@ public class BoardExceptionTest {
     @Test
     void deletePost_에서_게시글을_찾을_수_없습니다() {
         // given
-        PostRequestDto postRequestDto = PostRequestDto.builder()
-                .title("title")
-                .contents("contents")
-                .purpose(Purpose.PROJECT)
-                .status(Status.RECRUITMENT)
-                .fieldList(List.of(Field.BACKEND,Field.FRONTEND))
-                .languageList(List.of(Language.JAVA,Language.TS))
-                .fileUrlList(List.of("https://springbootpuzzletest.s3.ap-northeast-2.amazonaws.com/23752bbd-cd6e-4bde-986d-542df0517933.png"))
-                .build();
-
         boardService.post(postRequestDto);
 
         Long boardId = boardRepository.findAll().get(0).getId() + 1L;
 
         // when // then
-        CustomException customException = assertThrows(new CustomException(BOARD_NOT_FOUND).getClass(), () -> {
+        CustomException customException = assertThrows(CustomException.class, () -> {
             boardService.deletePost(boardId);
         });
 
@@ -184,13 +164,14 @@ public class BoardExceptionTest {
                 .contents("contents")
                 .purpose(Purpose.PROJECT)
                 .status(Status.RECRUITMENT)
+                .introduce("this is board")
                 .user(user)
                 .build();
 
         boardRepository.save(board);
 
         // when
-        CustomException customException = assertThrows(new CustomException(BOARD_NOT_HAVE_PERMISSION).getClass(), () -> {
+        CustomException customException = assertThrows(CustomException.class, () -> {
             boardService.deletePost(board.getId());
         });
 

--- a/src/test/java/com/server/Puzzle/service/attend/AttendServiceTest.java
+++ b/src/test/java/com/server/Puzzle/service/attend/AttendServiceTest.java
@@ -58,6 +58,17 @@ public class AttendServiceTest {
     @Autowired
     private EntityManager em;
 
+    final PostRequestDto postRequestDto = PostRequestDto.builder()
+            .title("title")
+            .contents("contents")
+            .purpose(Purpose.PROJECT)
+            .status(Status.RECRUITMENT)
+            .introduce("this is board")
+            .fieldList(List.of(Field.BACKEND,Field.FRONTEND))
+            .languageList(List.of(Language.JAVA,Language.TS))
+            .fileUrlList(List.of("https://springbootpuzzletest.s3.ap-northeast-2.amazonaws.com/23752bbd-cd6e-4bde-986d-542df0517933.png"))
+            .build();
+
     @BeforeEach
     void 로그인_되어있는_유저를_확인() {
         // given // when
@@ -89,16 +100,6 @@ public class AttendServiceTest {
     @Test
     void 프로젝트_참가_신청(){
         // given
-        PostRequestDto postRequestDto = PostRequestDto.builder()
-                .title("title")
-                .contents("contents")
-                .purpose(Purpose.PROJECT)
-                .status(Status.RECRUITMENT)
-                .fieldList(List.of(Field.BACKEND,Field.FRONTEND))
-                .languageList(List.of(Language.JAVA,Language.TS))
-                .fileUrlList(List.of("https://springbootpuzzletest.s3.ap-northeast-2.amazonaws.com/23752bbd-cd6e-4bde-986d-542df0517933.png"))
-                .build();
-
         boardService.post(postRequestDto);
 
         em.clear();
@@ -116,16 +117,6 @@ public class AttendServiceTest {
     @Test
     void 프로젝트_참가_신청_전체_조회(){
         // given
-        PostRequestDto postRequestDto = PostRequestDto.builder()
-                .title("title")
-                .contents("contents")
-                .purpose(Purpose.PROJECT)
-                .status(Status.RECRUITMENT)
-                .fieldList(List.of(Field.BACKEND,Field.FRONTEND))
-                .languageList(List.of(Language.JAVA,Language.TS))
-                .fileUrlList(List.of("https://springbootpuzzletest.s3.ap-northeast-2.amazonaws.com/23752bbd-cd6e-4bde-986d-542df0517933.png"))
-                .build();
-
         boardService.post(postRequestDto);
 
         em.clear();
@@ -145,16 +136,6 @@ public class AttendServiceTest {
     @Test
     void 프로젝트_참가_신청_수정() {
         // given
-        PostRequestDto postRequestDto = PostRequestDto.builder()
-                .title("title")
-                .contents("contents")
-                .purpose(Purpose.PROJECT)
-                .status(Status.RECRUITMENT)
-                .fieldList(List.of(Field.BACKEND,Field.FRONTEND))
-                .languageList(List.of(Language.JAVA,Language.TS))
-                .fileUrlList(List.of("https://springbootpuzzletest.s3.ap-northeast-2.amazonaws.com/23752bbd-cd6e-4bde-986d-542df0517933.png"))
-                .build();
-
         boardService.post(postRequestDto);
 
         em.clear();
@@ -180,16 +161,6 @@ public class AttendServiceTest {
     @Test
     void 프로젝트_참가_신청_취소(){
         // given
-        PostRequestDto postRequestDto = PostRequestDto.builder()
-                .title("title")
-                .contents("contents")
-                .purpose(Purpose.PROJECT)
-                .status(Status.RECRUITMENT)
-                .fieldList(List.of(Field.BACKEND,Field.FRONTEND))
-                .languageList(List.of(Language.JAVA,Language.TS))
-                .fileUrlList(List.of("https://springbootpuzzletest.s3.ap-northeast-2.amazonaws.com/23752bbd-cd6e-4bde-986d-542df0517933.png"))
-                .build();
-
         boardService.post(postRequestDto);
 
         em.clear();

--- a/src/test/java/com/server/Puzzle/service/board/BoardServiceTest.java
+++ b/src/test/java/com/server/Puzzle/service/board/BoardServiceTest.java
@@ -49,6 +49,17 @@ public class BoardServiceTest {
     @Autowired
     private EntityManager em;
 
+    final PostRequestDto postRequestDto = PostRequestDto.builder()
+            .title("title")
+            .contents("contents")
+            .purpose(Purpose.PROJECT)
+            .status(Status.RECRUITMENT)
+            .introduce("this is board")
+            .fieldList(List.of(Field.BACKEND,Field.FRONTEND))
+            .languageList(List.of(Language.JAVA,Language.TS))
+            .fileUrlList(List.of("https://springbootpuzzletest.s3.ap-northeast-2.amazonaws.com/23752bbd-cd6e-4bde-986d-542df0517933.png"))
+            .build();
+
     @BeforeEach
     void 로그인_되어있는_유저를_확인() {
         // given // when
@@ -79,18 +90,7 @@ public class BoardServiceTest {
 
     @Test
     void 게시물_등록(){
-        // given
-        PostRequestDto postRequestDto = PostRequestDto.builder()
-                .title("title")
-                .contents("contents")
-                .purpose(Purpose.PROJECT)
-                .status(Status.RECRUITMENT)
-                .fieldList(List.of(Field.BACKEND,Field.FRONTEND))
-                .languageList(List.of(Language.JAVA,Language.TS))
-                .fileUrlList(List.of("google.com","naver.com"))
-                .build();
-
-        // when
+        // given // when
         boardService.post(postRequestDto);
         em.clear();
 
@@ -121,21 +121,12 @@ public class BoardServiceTest {
     @Test
     void 게시물_수정(){
         // given
-        PostRequestDto postRequestDto = PostRequestDto.builder()
-                .title("title")
-                .contents("contents")
-                .purpose(Purpose.PROJECT)
-                .status(Status.RECRUITMENT)
-                .fieldList(List.of(Field.BACKEND,Field.FRONTEND))
-                .languageList(List.of(Language.JAVA,Language.TS))
-                .fileUrlList(List.of("https://springbootpuzzletest.s3.ap-northeast-2.amazonaws.com/23752bbd-cd6e-4bde-986d-542df0517933.png"))
-                .build();
-
         CorrectionPostRequestDto correctionPostRequestDto = CorrectionPostRequestDto.builder()
                 .title("correctionTitle")
                 .contents("correctionContents")
                 .purpose(Purpose.PROJECT)
                 .status(Status.RECRUITMENT)
+                .introduce("this is board")
                 .fileUrlList(List.of("https://springbootpuzzletest.s3.ap-northeast-2.amazonaws.com/23752bbd-cd6e-4bde-986d-542df0517933.png"))
                 .languageList(List.of(Language.PYTORCH, Language.KOTLIN))
                 .fieldList(List.of(Field.AI,Field.ANDROID))
@@ -157,16 +148,6 @@ public class BoardServiceTest {
     @Test
     void 게시물_전체_조회(){
         // given
-        PostRequestDto postRequestDto = PostRequestDto.builder()
-                .title("title")
-                .contents("contents")
-                .purpose(Purpose.PROJECT)
-                .status(Status.RECRUITMENT)
-                .fieldList(List.of(Field.BACKEND,Field.FRONTEND))
-                .languageList(List.of(Language.JAVA,Language.TS))
-                .fileUrlList(List.of("https://springbootpuzzletest.s3.ap-northeast-2.amazonaws.com/23752bbd-cd6e-4bde-986d-542df0517933.png"))
-                .build();
-
         for (int i = 0; i < 12; i++){
             boardService.post(postRequestDto);
         }
@@ -180,18 +161,7 @@ public class BoardServiceTest {
 
     @Test
     void 게시물_단일_조회(){
-        // given
-        PostRequestDto postRequestDto = PostRequestDto.builder()
-                .title("title")
-                .contents("contents")
-                .purpose(Purpose.PROJECT)
-                .status(Status.RECRUITMENT)
-                .fieldList(List.of(Field.BACKEND,Field.FRONTEND))
-                .languageList(List.of(Language.JAVA,Language.TS))
-                .fileUrlList(List.of("https://springbootpuzzletest.s3.ap-northeast-2.amazonaws.com/23752bbd-cd6e-4bde-986d-542df0517933.png"))
-                .build();
-
-        // when
+        // given // when
         boardService.post(postRequestDto);
         Board findBoard = boardRepository.findAll().get(0);
 
@@ -204,17 +174,7 @@ public class BoardServiceTest {
     @Disabled
     @Test
     void 게시물_삭제(){
-        // then
-        PostRequestDto postRequestDto = PostRequestDto.builder()
-                .title("title")
-                .contents("contents")
-                .purpose(Purpose.PROJECT)
-                .status(Status.RECRUITMENT)
-                .fieldList(List.of(Field.BACKEND,Field.FRONTEND))
-                .languageList(List.of(Language.JAVA,Language.TS))
-                .fileUrlList(List.of("https://springbootpuzzletest.s3.ap-northeast-2.amazonaws.com/23752bbd-cd6e-4bde-986d-542df0517933.png"))
-                .build();
-
+        // given
         boardService.post(postRequestDto);
 
         // when
@@ -233,6 +193,7 @@ public class BoardServiceTest {
                 .contents("contents1")
                 .purpose(Purpose.PROJECT)
                 .status(Status.RECRUITMENT)
+                .introduce("this is introduce")
                 .fieldList(List.of(Field.BACKEND,Field.FRONTEND))
                 .languageList(List.of(Language.JAVA,Language.TS))
                 .fileUrlList(List.of("https://springbootpuzzletest.s3.ap-northeast-2.amazonaws.com/23752bbd-cd6e-4bde-986d-542df0517933.png"))
@@ -241,6 +202,7 @@ public class BoardServiceTest {
         PostRequestDto postRequestDto2 = PostRequestDto.builder()
                 .title("title2")
                 .contents("contents2")
+                .introduce("this is introduce")
                 .purpose(Purpose.SERVICE)
                 .status(Status.RECRUITMENT)
                 .fieldList(List.of(Field.BACKEND,Field.FRONTEND))
@@ -251,6 +213,7 @@ public class BoardServiceTest {
         PostRequestDto postRequestDto3 = PostRequestDto.builder()
                 .title("title3")
                 .contents("contents3")
+                .introduce("this is introduce")
                 .purpose(Purpose.STUDY)
                 .status(Status.RECRUITMENT)
                 .fieldList(List.of(Field.AI,Field.GAME))


### PR DESCRIPTION
### 제가 한 일은요!!
- 기존의 게시글 을 조회하면서 게시글 소개를 표시할떄 그냥 content를 반환해서 마크다운 문법이 다 들어갔지만,
 `introduce` 를 따로 분리 함으로써 정상적으로 보일 수 있게 했습니다.
- Board 엔티티에 `introduce` 컬럼을 추가했습니다.
- Board 서비스 코드를 일부 리팩토링 했습니다.

### 에러가 발생합니다
<img width="1535" alt="2022-06-14_16-23-47" src="https://user-images.githubusercontent.com/68670670/173518671-74dc4970-401a-412c-afe4-9a2b0745a300.png">  

- introduce 컬럼을 추가하여 기존의 테스트코드에서 board 를 post하는 부분에서 에러가 발생합니다.
확인하고 수정해주세요 @honghyunin 

