### PR TITLE
프론트 컴포넌트 이슈로 인한 deleteAttend 로직 변경

### DIFF
--- a/src/main/java/com/server/Puzzle/domain/attend/controller/AttendController.java
+++ b/src/main/java/com/server/Puzzle/domain/attend/controller/AttendController.java
@@ -46,9 +46,9 @@ public class AttendController {
     @ApiImplicitParams({
             @ApiImplicitParam(name = "Authorization", value = "로그인 성공 후 access_token", required = true, dataType = "String", paramType = "header")
     })
-    @DeleteMapping("/{attendId}")
-    public ResponseEntity<String> deleteAttend(@PathVariable Long attendId) {
-        attendService.deleteAttend(attendId);
+    @DeleteMapping("/board/{boardId}")
+    public ResponseEntity<String> deleteAttend(@PathVariable Long boardId) {
+        attendService.deleteAttend(boardId);
         return ResponseEntity.ok("Success");
     }
 

--- a/src/main/java/com/server/Puzzle/domain/attend/controller/AttendController.java
+++ b/src/main/java/com/server/Puzzle/domain/attend/controller/AttendController.java
@@ -30,7 +30,7 @@ public class AttendController {
 
     @GetMapping("/board/{boardId}")
     public ResponseEntity<List<GetAllAttendResponse>> getAllAttend(@PathVariable Long boardId){
-        List<GetAllAttendResponse> response = attendService.findAllAttend(boardId);
+        List<GetAllAttendResponse> response = attendService.getAllAttend(boardId);
         return ResponseEntity.ok().body(response);
     }
 

--- a/src/main/java/com/server/Puzzle/domain/attend/controller/AttendController.java
+++ b/src/main/java/com/server/Puzzle/domain/attend/controller/AttendController.java
@@ -1,7 +1,7 @@
 package com.server.Puzzle.domain.attend.controller;
 
 import com.server.Puzzle.domain.attend.dto.request.PatchAttendRequest;
-import com.server.Puzzle.domain.attend.dto.response.GetAllAttendResponse;
+import com.server.Puzzle.domain.attend.dto.response.FindAllAttendResponse;
 import com.server.Puzzle.domain.attend.service.AttendService;
 import com.server.Puzzle.domain.board.enumType.IsAttendStatus;
 import io.swagger.annotations.ApiImplicitParam;
@@ -29,8 +29,8 @@ public class AttendController {
     }
 
     @GetMapping("/board/{boardId}")
-    public ResponseEntity<List<GetAllAttendResponse>> getAllAttend(@PathVariable Long boardId){
-        List<GetAllAttendResponse> response = attendService.getAllAttend(boardId);
+    public ResponseEntity<List<FindAllAttendResponse>> FindAllAttend(@PathVariable Long boardId){
+        List<FindAllAttendResponse> response = attendService.findAllAttend(boardId);
         return ResponseEntity.ok().body(response);
     }
 

--- a/src/main/java/com/server/Puzzle/domain/attend/dto/response/FindAllAttendResponse.java
+++ b/src/main/java/com/server/Puzzle/domain/attend/dto/response/FindAllAttendResponse.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @Getter
-public class GetAllAttendResponse {
+public class FindAllAttendResponse {
 
     private Long id;
     private List<Language> languages;

--- a/src/main/java/com/server/Puzzle/domain/attend/repository/AttendCustomRepository.java
+++ b/src/main/java/com/server/Puzzle/domain/attend/repository/AttendCustomRepository.java
@@ -1,13 +1,13 @@
 package com.server.Puzzle.domain.attend.repository;
 
-import com.server.Puzzle.domain.attend.dto.response.GetAllAttendResponse;
+import com.server.Puzzle.domain.attend.dto.response.FindAllAttendResponse;
 import com.server.Puzzle.domain.board.domain.Board;
 
 import java.util.List;
 
 public interface AttendCustomRepository {
 
-    List<GetAllAttendResponse> findAllByBoardId(Long boardId);
+    List<FindAllAttendResponse> findAllByBoardId(Long boardId);
     Board findBoardByAttendId(Long attendId);
 
 }

--- a/src/main/java/com/server/Puzzle/domain/attend/repository/AttendCustomRepositoryImpl.java
+++ b/src/main/java/com/server/Puzzle/domain/attend/repository/AttendCustomRepositoryImpl.java
@@ -2,7 +2,7 @@ package com.server.Puzzle.domain.attend.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.server.Puzzle.domain.attend.domain.Attend;
-import com.server.Puzzle.domain.attend.dto.response.GetAllAttendResponse;
+import com.server.Puzzle.domain.attend.dto.response.FindAllAttendResponse;
 import com.server.Puzzle.domain.board.domain.Board;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -21,13 +21,13 @@ public class AttendCustomRepositoryImpl implements AttendCustomRepository{
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<GetAllAttendResponse> findAllByBoardId(Long boardId) {
+    public List<FindAllAttendResponse> findAllByBoardId(Long boardId) {
         List<Attend> attends = jpaQueryFactory.selectFrom(attend)
                 .where(attend.board.id.eq(boardId))
                 .fetch();
 
         return attends.stream()
-                .map(a -> new GetAllAttendResponse(
+                .map(a -> new FindAllAttendResponse(
                         a.getId(),
                         a.getUser().getUserLanguages().stream()
                                 .map(l -> l.getLanguage())

--- a/src/main/java/com/server/Puzzle/domain/attend/service/AttendService.java
+++ b/src/main/java/com/server/Puzzle/domain/attend/service/AttendService.java
@@ -14,7 +14,7 @@ public interface AttendService {
 
     void patchAttend(Long attendId, PatchAttendRequest patchAttendRequest);
 
-    void deleteAttend(Long attendId);
+    void deleteAttend(Long boardId);
 
     IsAttendStatus checkAttendStatus(Long boardId);
 }

--- a/src/main/java/com/server/Puzzle/domain/attend/service/AttendService.java
+++ b/src/main/java/com/server/Puzzle/domain/attend/service/AttendService.java
@@ -1,7 +1,7 @@
 package com.server.Puzzle.domain.attend.service;
 
 import com.server.Puzzle.domain.attend.dto.request.PatchAttendRequest;
-import com.server.Puzzle.domain.attend.dto.response.GetAllAttendResponse;
+import com.server.Puzzle.domain.attend.dto.response.FindAllAttendResponse;
 import com.server.Puzzle.domain.board.enumType.IsAttendStatus;
 
 import java.util.List;
@@ -10,7 +10,7 @@ public interface AttendService {
 
     void requestAttend(Long boardId);
 
-    List<GetAllAttendResponse> getAllAttend(Long boardId);
+    List<FindAllAttendResponse> findAllAttend(Long boardId);
 
     void patchAttend(Long attendId, PatchAttendRequest patchAttendRequest);
 

--- a/src/main/java/com/server/Puzzle/domain/attend/service/AttendService.java
+++ b/src/main/java/com/server/Puzzle/domain/attend/service/AttendService.java
@@ -10,7 +10,7 @@ public interface AttendService {
 
     void requestAttend(Long boardId);
 
-    List<GetAllAttendResponse> findAllAttend(Long boardId);
+    List<GetAllAttendResponse> getAllAttend(Long boardId);
 
     void patchAttend(Long attendId, PatchAttendRequest patchAttendRequest);
 

--- a/src/main/java/com/server/Puzzle/domain/attend/service/Impl/AttendServiceImpl.java
+++ b/src/main/java/com/server/Puzzle/domain/attend/service/Impl/AttendServiceImpl.java
@@ -67,15 +67,18 @@ public class AttendServiceImpl implements AttendService {
     }
 
     @Override
-    public void deleteAttend(Long attendId) {
+    public void deleteAttend(Long boardId) {
         User currentUser = currentUserUtil.getCurrentUser();
 
-        Attend attend = attendRepository.findById(attendId)
-                .orElseThrow(() -> new CustomException(ErrorCode.ATTEND_NOT_FOUND));
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new CustomException(ErrorCode.BOARD_NOT_FOUND));
 
-        if (!attend.isAttend(currentUser)) throw new CustomException(ErrorCode.ATTEND_DELETE_PERMISSION_DENIED);
+        Long attendId = board.getAttends().stream()
+                .filter(a -> a.isAttend(currentUser)).findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.ATTEND_DELETE_PERMISSION_DENIED))
+                .getId();
 
-        attendRepository.deleteById(attend.getId());
+        attendRepository.deleteById(attendId);
     }
 
     @Override

--- a/src/main/java/com/server/Puzzle/domain/attend/service/Impl/AttendServiceImpl.java
+++ b/src/main/java/com/server/Puzzle/domain/attend/service/Impl/AttendServiceImpl.java
@@ -2,7 +2,7 @@ package com.server.Puzzle.domain.attend.service.Impl;
 
 import com.server.Puzzle.domain.attend.domain.Attend;
 import com.server.Puzzle.domain.attend.dto.request.PatchAttendRequest;
-import com.server.Puzzle.domain.attend.dto.response.GetAllAttendResponse;
+import com.server.Puzzle.domain.attend.dto.response.FindAllAttendResponse;
 import com.server.Puzzle.domain.attend.enumtype.AttendStatus;
 import com.server.Puzzle.domain.attend.repository.AttendRepository;
 import com.server.Puzzle.domain.attend.service.AttendService;
@@ -47,7 +47,7 @@ public class AttendServiceImpl implements AttendService {
     }
 
     @Override
-    public List<GetAllAttendResponse> getAllAttend(Long boardId) {
+    public List<FindAllAttendResponse> findAllAttend(Long boardId) {
         boardRepository.findById(boardId)
                 .orElseThrow(() -> new CustomException(ErrorCode.BOARD_NOT_FOUND));
 

--- a/src/main/java/com/server/Puzzle/domain/attend/service/Impl/AttendServiceImpl.java
+++ b/src/main/java/com/server/Puzzle/domain/attend/service/Impl/AttendServiceImpl.java
@@ -47,7 +47,7 @@ public class AttendServiceImpl implements AttendService {
     }
 
     @Override
-    public List<GetAllAttendResponse> findAllAttend(Long boardId) {
+    public List<GetAllAttendResponse> getAllAttend(Long boardId) {
         boardRepository.findById(boardId)
                 .orElseThrow(() -> new CustomException(ErrorCode.BOARD_NOT_FOUND));
 
@@ -75,7 +75,7 @@ public class AttendServiceImpl implements AttendService {
 
         Long attendId = board.getAttends().stream()
                 .filter(a -> a.isAttend(currentUser)).findFirst()
-                .orElseThrow(() -> new CustomException(ErrorCode.ATTEND_DELETE_PERMISSION_DENIED))
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_ATTEND))
                 .getId();
 
         attendRepository.deleteById(attendId);

--- a/src/main/java/com/server/Puzzle/global/exception/ErrorCode.java
+++ b/src/main/java/com/server/Puzzle/global/exception/ErrorCode.java
@@ -21,7 +21,7 @@ public enum ErrorCode {
     IS_ALREADY_ATTEND(400,"이미 신청되어 있습니다"),
     ATTEND_PATCH_PERMISSION_DENIED(401, "신청을 수정할 권한이 존재하지 않습니다."),
     ATTEND_NOT_FOUND(404, "신청을 찾을 수 없습니다."),
-    ATTEND_DELETE_PERMISSION_DENIED(401, "신청을 삭제할 권한이 존재하지 않습니다.");
+    NOT_ATTEND(400,"신청을 하지 않았습니다.");
 
     private final int status;
     private final String detail;

--- a/src/test/java/com/server/Puzzle/service/attend/AttendServiceTest.java
+++ b/src/test/java/com/server/Puzzle/service/attend/AttendServiceTest.java
@@ -2,7 +2,7 @@ package com.server.Puzzle.service.attend;
 
 import com.server.Puzzle.domain.attend.domain.Attend;
 import com.server.Puzzle.domain.attend.dto.request.PatchAttendRequest;
-import com.server.Puzzle.domain.attend.dto.response.GetAllAttendResponse;
+import com.server.Puzzle.domain.attend.dto.response.FindAllAttendResponse;
 import com.server.Puzzle.domain.attend.enumtype.AttendStatus;
 import com.server.Puzzle.domain.attend.repository.AttendRepository;
 import com.server.Puzzle.domain.attend.service.AttendService;
@@ -127,7 +127,7 @@ public class AttendServiceTest {
         em.clear();
 
         // when
-        List<GetAllAttendResponse> allAttend = attendService.getAllAttend(board.getId());
+        List<FindAllAttendResponse> allAttend = attendService.findAllAttend(board.getId());
 
         // then
         assertThat(allAttend).isNotNull();

--- a/src/test/java/com/server/Puzzle/service/attend/AttendServiceTest.java
+++ b/src/test/java/com/server/Puzzle/service/attend/AttendServiceTest.java
@@ -127,7 +127,7 @@ public class AttendServiceTest {
         em.clear();
 
         // when
-        List<GetAllAttendResponse> allAttend = attendService.findAllAttend(board.getId());
+        List<GetAllAttendResponse> allAttend = attendService.getAllAttend(board.getId());
 
         // then
         assertThat(allAttend).isNotNull();

--- a/src/test/java/com/server/Puzzle/service/attend/AttendServiceTest.java
+++ b/src/test/java/com/server/Puzzle/service/attend/AttendServiceTest.java
@@ -166,14 +166,13 @@ public class AttendServiceTest {
         em.clear();
 
         Board board = boardRepository.findAll().get(0);
-
-        attendService.requestAttend(board.getId());
+        Long boardId = board.getId();
+        attendService.requestAttend(boardId);
         Long attendId = attendRepository.findAll().get(0).getId();
-
         em.clear();
 
         // when
-        attendService.deleteAttend(attendId);
+        attendService.deleteAttend(boardId);
 
         // then
         assertThat(attendRepository.findById(attendId).isEmpty()).isTrue();


### PR DESCRIPTION
### 제가 한 일은요!!
- 프론트 컴포넌트 이슈로 인하여 deleteAttend 의 로직을 변경했습니다.
- 신청자 목록을 전체조회하는 api의 메소드명을 변경했습니다. (findAllAttend -> getAllAttend)

### 무슨 컴포넌트 이슈가 있었나요??
<img width="1360" alt="2022-06-18_16-45-27" src="https://user-images.githubusercontent.com/68670670/174428365-4e969611-ee8b-40be-a0ed-4040545b5725.png">

신청자 목록 전체조회를 할때 `attendId` 를 반환 해주지만, 
현재 이런상태로 **버튼의 컴포넌트**와 **신청자 목록의 컴포넌트**가 달라서 
**버튼의 컴포넌트**에서는 `attendId` 를 사용할 수 없었습니다.

그래서 url 에 있는 boardId 를 활용하여 게시글을 조회를 한 후
신청자들을 찾아서 토큰에서 유저의 정보를 가져와 일치한다면 신청을 취소할 수 있도록 했습니다.

