### PR TITLE
테스트 커버리지 관리를 위한 jacoco 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,14 +99,14 @@ jacocoTestReport {
 		})
 	}
 
-//	finalizedBy 'jacocoTestCoverageVerification'
+	finalizedBy 'jacocoTestCoverageVerification'
 }
 
 // 테스트 커버리지 체크 단위 설정 ( 빌드 성공 조건 )
-/*jacocoTestCoverageVerification {
+jacocoTestCoverageVerification {
 	violationRules {
 		rule {
-			enabled = true // 룰 적용
+			enabled = false // 룰 적용 안함
 			element = 'BUNDLE' // Bundle(패키지) 단위
 
 			limit {
@@ -116,7 +116,7 @@ jacocoTestReport {
 			}
 		}
 	}
-}*/
+}
 
 // ====================================== //
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
 	id 'java'
 	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10" //querydsl
 	id "io.franzbecker.gradle-lombok" version "3.0.0"
+	id 'jacoco'
 }
 
 group = 'com.server'
@@ -64,10 +65,62 @@ dependencies {
 }
 
 test {
+	// jacoco 사용 선언
+	jacoco {
+		enabled = true
+		destinationFile = file("$buildDir/jacoco/${name}.exec")
+		output = JacocoTaskExtension.Output.FILE
+	}
 	useJUnitPlatform()
+	finalizedBy 'jacocoTestReport'
 }
 
-//querydsl 추가 시작
+// ============== jacoco =============== //
+jacocoTestReport {
+	reports {
+		html.enabled true
+		xml.enabled false
+		csv.enabled false
+	}
+
+	// 테스트 커버리지를 제외하는 경로들 ( 초반에는 controller, service 로직에만 집중 )
+	afterEvaluate {
+		classDirectories.from = files(classDirectories.files.collect {
+			fileTree(dir: it, exclude: [
+					'**/exception/**'
+					,'**/dto/**'
+					,'**/repository/**'
+					,'**/config/**'
+					,'**/health_check/**'
+					,'**/Puzzle/PuzzleApplication*'
+					,'**/Puzzle/**/Q*'
+					,'**/Puzzle/global/**'
+			])
+		})
+	}
+
+	finalizedBy 'jacocoTestCoverageVerification'
+}
+
+// 테스트 커버리지 체크 단위 설정 ( 빌드 성공 조건 )
+jacocoTestCoverageVerification {
+	violationRules {
+		rule {
+			enabled = true // 룰 적용
+			element = 'BUNDLE' // Bundle(패키지) 단위
+
+			limit {
+				counter = 'INSTRUCTION' // 커버리지 측정의 최소 단위를 Java 바이트코드 명령 수로 지정 ( Missed Instructions 가 50퍼센트 이상일때 )
+				value = 'COVEREDRATIO' // 커버된 개수
+				minimum = 0.50 // 50퍼센트 이상일시
+			}
+		}
+	}
+}
+
+// ====================================== //
+
+// ============== querydsl =============== //
 def querydslDir = "$buildDir/generated/querydsl"
 querydsl {
 	jpa = true
@@ -82,3 +135,4 @@ configurations {
 compileQuerydsl {
 	options.annotationProcessorPath = configurations.querydsl
 }
+// ====================================== //

--- a/build.gradle
+++ b/build.gradle
@@ -99,11 +99,11 @@ jacocoTestReport {
 		})
 	}
 
-	finalizedBy 'jacocoTestCoverageVerification'
+//	finalizedBy 'jacocoTestCoverageVerification'
 }
 
 // 테스트 커버리지 체크 단위 설정 ( 빌드 성공 조건 )
-jacocoTestCoverageVerification {
+/*jacocoTestCoverageVerification {
 	violationRules {
 		rule {
 			enabled = true // 룰 적용
@@ -116,7 +116,7 @@ jacocoTestCoverageVerification {
 			}
 		}
 	}
-}
+}*/
 
 // ====================================== //
 


### PR DESCRIPTION
### 제가 한 일은요!!
- 테스트 커버리지 관리를 위한 jacoco 를 도입했습니다!!

### 코멘트
- 우선 jacoco 를 처음 도입 했기에 처음에는 `controller` 와 `service` 의 테스트 커버리지만 집중하여 하기 위하여 `controller` 와 `service` 를 제외한 나머지 패키지는 제외 했습니다.  
( 나중에 하나하나씩 늘릴 예정 )

- jacoco 에는 특정 커버리지를 넘겨야지 빌드가 success 되는 옵션이 있는데 해당 옵션은 적용하지 않았습니다.
- 테스트 커버리지에 포함되지 않는 패키지(ignore된 패키지)들까지 포함되어 제대로 적용되지 못합니다. 
나중에 적용하도록 하겠습니다. ( 주석처리된 부분 )

### 제외된 패키지
<img width="568" alt="2022-06-20_17-11-47" src="https://user-images.githubusercontent.com/68670670/174556001-54e44a3c-d4e1-410c-96f1-2d3e99aaf7e9.png">

### 적용된 패키지
<img width="1102" alt="2022-06-20_17-12-33" src="https://user-images.githubusercontent.com/68670670/174556121-44ac3960-bdfa-41db-ae37-85ed39189191.png">

