### PR TITLE
mockMvc ProfileController Test 작성

### DIFF
--- a/src/test/java/com/server/Puzzle/controller/profile/ProfileControllerTest.java
+++ b/src/test/java/com/server/Puzzle/controller/profile/ProfileControllerTest.java
@@ -1,0 +1,9 @@
+package com.server.Puzzle.controller.profile;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ProfileControllerTest {
+
+}

--- a/src/test/java/com/server/Puzzle/controller/profile/ProfileControllerTest.java
+++ b/src/test/java/com/server/Puzzle/controller/profile/ProfileControllerTest.java
@@ -40,6 +40,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ExtendWith(MockitoExtension.class)
 public class ProfileControllerTest {
 
+    private static final String URL = "/api/profile/";
+
     @InjectMocks
     private ProfileController profileController;
 
@@ -68,7 +70,7 @@ public class ProfileControllerTest {
                 .getUserBoard(githubId, pageable);
 
         ResultActions resultActions = mockMvc.perform(
-                MockMvcRequestBuilders.get("/api/profile/{githubId}/board", githubId)
+                MockMvcRequestBuilders.get(URL + "/{githubId}/board", githubId)
                         .queryParam("page", "0")
                         .queryParam("size", "5")
         );
@@ -92,7 +94,7 @@ public class ProfileControllerTest {
         doReturn(response).when(profileService)
                 .getProfile(githubId);
 
-        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/api/profile/{githubId}", githubId));
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get(URL + "/{githubId}", githubId));
 
         resultActions
                 .andExpect(jsonPath("email", notNullValue()))
@@ -110,7 +112,7 @@ public class ProfileControllerTest {
         ProfileUpdateDto request = profileInfo();
 
         ResultActions resultActions = mockMvc.perform(
-                MockMvcRequestBuilders.get("/api/profile/update")
+                MockMvcRequestBuilders.get(URL + "/update")
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(new Gson().toJson(request))
                         .characterEncoding("UTF-8")

--- a/src/test/java/com/server/Puzzle/controller/profile/ProfileControllerTest.java
+++ b/src/test/java/com/server/Puzzle/controller/profile/ProfileControllerTest.java
@@ -26,14 +26,13 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.CharacterEncodingFilter;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.doReturn;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
@@ -51,6 +50,8 @@ public class ProfileControllerTest {
     public void init() {
         mockMvc = MockMvcBuilders.standaloneSetup(profileController)
                 .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
+                .addFilters(new CharacterEncodingFilter("UTF-8", true))
+                .alwaysDo(print())
                 .build();
     }
 
@@ -60,7 +61,6 @@ public class ProfileControllerTest {
         String githubId = "honghyunin";
 
         Page<UserBoardResponse> response = responseUserBoard(pageable);
-        UserBoardResponse boards = getUserBoards();
 
         doReturn(response).when(profileService)
                 .getUserBoard(githubId, pageable);
@@ -70,16 +70,7 @@ public class ProfileControllerTest {
                         .queryParam("page", "0")
                         .queryParam("size", "5")
         );
-        resultActions.andExpect(status().isOk())
-                .andExpect(jsonPath("$.content[0].boardId", notNullValue()))
-                .andExpect(jsonPath("$.content[0].title", notNullValue()))
-                .andExpect(jsonPath("$.content[0].date", notNullValue()))
-                .andExpect(jsonPath("$.content[0].contents", notNullValue()))
-                .andExpect(jsonPath("$.content[0].introduce", notNullValue()))
-                .andExpect(jsonPath("$.content[0].status", notNullValue()))
-                .andExpect(jsonPath("$.content[0].thumbnail", notNullValue()))
-                .andExpect(jsonPath("$.content[0].fields", notNullValue()))
-                .andExpect(jsonPath("$.content[0].purpose", notNullValue()));
+        resultActions.andExpect(status().isOk());
     }
 
     @Test
@@ -92,14 +83,7 @@ public class ProfileControllerTest {
 
         ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/api/profile/{githubId}", githubId));
 
-        resultActions.andDo(print())
-                .andExpect(jsonPath("email", notNullValue()))
-                .andExpect(jsonPath("name", notNullValue()))
-                .andExpect(jsonPath("bio", notNullValue()))
-                .andExpect(jsonPath("url", notNullValue()))
-                .andExpect(jsonPath("field", notNullValue()))
-                .andExpect(jsonPath("languages", notNullValue()))
-                .andExpect(jsonPath("imageUrl", notNullValue()));
+        resultActions.andExpect(status().isOk());
         ;
     }
 
@@ -114,8 +98,7 @@ public class ProfileControllerTest {
                         .characterEncoding("UTF-8")
         );
 
-        resultActions.andDo(print())
-                .andExpect(status().isOk());
+        resultActions.andExpect(status().isOk());
     }
 
     private ProfileUpdateDto profileInfo() {
@@ -144,6 +127,7 @@ public class ProfileControllerTest {
         UserBoardResponse boards = getUserBoards();
         return new PageImpl<>(List.of(boards), pageable, 1);
     }
+
     private UserBoardResponse getUserBoards() {
         return UserBoardResponse.builder()
                 .boardId(1L)
@@ -152,7 +136,7 @@ public class ProfileControllerTest {
                 .fields(List.of(Field.BACKEND, Field.FRONTEND))
                 .status(Status.ALL)
                 .purpose(Purpose.PROJECT)
-                .introduce("introduce")
+                .introduce("아이엠스튜디오")
                 .contents("contents")
                 .date(LocalDateTime.now())
                 .build();

--- a/src/test/java/com/server/Puzzle/controller/profile/ProfileControllerTest.java
+++ b/src/test/java/com/server/Puzzle/controller/profile/ProfileControllerTest.java
@@ -1,9 +1,160 @@
 package com.server.Puzzle.controller.profile;
 
+import com.google.gson.Gson;
+import com.server.Puzzle.domain.board.enumType.Purpose;
+import com.server.Puzzle.domain.board.enumType.Status;
+import com.server.Puzzle.domain.user.controller.ProfileController;
+import com.server.Puzzle.domain.user.dto.ProfileUpdateDto;
+import com.server.Puzzle.domain.user.dto.UserBoardResponse;
+import com.server.Puzzle.domain.user.dto.UserProfileResponse;
+import com.server.Puzzle.domain.user.service.ProfileService;
+import com.server.Puzzle.global.enumType.Field;
+import com.server.Puzzle.global.enumType.Language;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
 public class ProfileControllerTest {
 
+    @InjectMocks
+    private ProfileController profileController;
+
+    @Mock
+    private ProfileService profileService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void init() {
+        mockMvc = MockMvcBuilders.standaloneSetup(profileController)
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
+                .build();
+    }
+
+    @Test
+    void 유저_작성글_조회_성공() throws Exception {
+        Pageable pageable = PageRequest.of(0, 5);
+        String githubId = "honghyunin";
+
+        Page<UserBoardResponse> response = responseUserBoard(pageable);
+        UserBoardResponse boards = getUserBoards();
+
+        doReturn(response).when(profileService)
+                .getUserBoard(githubId, pageable);
+
+        ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.get("/api/profile/{githubId}/board", githubId)
+                        .queryParam("page", "0")
+                        .queryParam("size", "5")
+        );
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].boardId", notNullValue()))
+                .andExpect(jsonPath("$.content[0].title", notNullValue()))
+                .andExpect(jsonPath("$.content[0].date", notNullValue()))
+                .andExpect(jsonPath("$.content[0].contents", notNullValue()))
+                .andExpect(jsonPath("$.content[0].introduce", notNullValue()))
+                .andExpect(jsonPath("$.content[0].status", notNullValue()))
+                .andExpect(jsonPath("$.content[0].thumbnail", notNullValue()))
+                .andExpect(jsonPath("$.content[0].fields", notNullValue()))
+                .andExpect(jsonPath("$.content[0].purpose", notNullValue()));
+    }
+
+    @Test
+    void 유저_프로필_조회_성공() throws Exception {
+        String githubId = "honghyunin";
+        UserProfileResponse response = getUserProfile();
+
+        doReturn(response).when(profileService)
+                .getProfile(githubId);
+
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/api/profile/{githubId}", githubId));
+
+        resultActions.andDo(print())
+                .andExpect(jsonPath("email", notNullValue()))
+                .andExpect(jsonPath("name", notNullValue()))
+                .andExpect(jsonPath("bio", notNullValue()))
+                .andExpect(jsonPath("url", notNullValue()))
+                .andExpect(jsonPath("field", notNullValue()))
+                .andExpect(jsonPath("languages", notNullValue()))
+                .andExpect(jsonPath("imageUrl", notNullValue()));
+        ;
+    }
+
+    @Test
+    void 유저_프로필_변경_성공() throws Exception {
+        ProfileUpdateDto request = profileInfo();
+
+        ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.get("/api/profile/update")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content(new Gson().toJson(request))
+                        .characterEncoding("UTF-8")
+        );
+
+        resultActions.andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    private ProfileUpdateDto profileInfo() {
+        return ProfileUpdateDto.builder()
+                .email("hyunin0102@gmail.com")
+                .name("hyunin")
+                .field(Field.BACKEND)
+                .bio("bio")
+                .language(List.of(Language.SPRING, Language.DJANGO))
+                .build();
+    }
+
+    private UserProfileResponse getUserProfile() {
+        return UserProfileResponse.builder()
+                .email("hyunin0102@gmail.com")
+                .name("hyunin")
+                .bio("i am bio")
+                .field(Field.BACKEND)
+                .imageUrl("imageurl")
+                .url("url")
+                .languages(List.of(Language.SPRING, Language.SPRINGBOOT))
+                .build();
+    }
+
+    private Page<UserBoardResponse> responseUserBoard(Pageable pageable) {
+        UserBoardResponse boards = getUserBoards();
+        return new PageImpl<>(List.of(boards), pageable, 1);
+    }
+    private UserBoardResponse getUserBoards() {
+        return UserBoardResponse.builder()
+                .boardId(1L)
+                .title("title")
+                .thumbnail("thumbnail")
+                .fields(List.of(Field.BACKEND, Field.FRONTEND))
+                .status(Status.ALL)
+                .purpose(Purpose.PROJECT)
+                .introduce("introduce")
+                .contents("contents")
+                .date(LocalDateTime.now())
+                .build();
+    }
 }

--- a/src/test/java/com/server/Puzzle/controller/profile/ProfileControllerTest.java
+++ b/src/test/java/com/server/Puzzle/controller/profile/ProfileControllerTest.java
@@ -31,8 +31,10 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.doReturn;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
@@ -70,7 +72,16 @@ public class ProfileControllerTest {
                         .queryParam("page", "0")
                         .queryParam("size", "5")
         );
-        resultActions.andExpect(status().isOk());
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].boardId", notNullValue()))
+                .andExpect(jsonPath("$.content[0].title", notNullValue()))
+                .andExpect(jsonPath("$.content[0].date", notNullValue()))
+                .andExpect(jsonPath("$.content[0].contents", notNullValue()))
+                .andExpect(jsonPath("$.content[0].introduce", notNullValue()))
+                .andExpect(jsonPath("$.content[0].status", notNullValue()))
+                .andExpect(jsonPath("$.content[0].thumbnail", notNullValue()))
+                .andExpect(jsonPath("$.content[0].fields", notNullValue()))
+                .andExpect(jsonPath("$.content[0].purpose", notNullValue()));
     }
 
     @Test
@@ -83,7 +94,14 @@ public class ProfileControllerTest {
 
         ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/api/profile/{githubId}", githubId));
 
-        resultActions.andExpect(status().isOk());
+        resultActions
+                .andExpect(jsonPath("email", notNullValue()))
+                .andExpect(jsonPath("name", notNullValue()))
+                .andExpect(jsonPath("bio", notNullValue()))
+                .andExpect(jsonPath("url", notNullValue()))
+                .andExpect(jsonPath("field", notNullValue()))
+                .andExpect(jsonPath("languages", notNullValue()))
+                .andExpect(jsonPath("imageUrl", notNullValue()));
         ;
     }
 

--- a/src/test/java/com/server/Puzzle/controller/user/UserControllerTest.java
+++ b/src/test/java/com/server/Puzzle/controller/user/UserControllerTest.java
@@ -28,6 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ExtendWith(MockitoExtension.class)
 class UserControllerTest {
 
+    private static final String URL = "/api/user";
     @InjectMocks
     private UserController userController;
 
@@ -48,7 +49,7 @@ class UserControllerTest {
                 .logout();
 
         ResultActions resultActions = mockMvc.perform(
-                MockMvcRequestBuilders.delete("/api/user/logout")
+                MockMvcRequestBuilders.delete(URL + "/logout")
         );
 
         resultActions.andExpect(status().isOk());
@@ -60,7 +61,7 @@ class UserControllerTest {
                 .delete();
 
         ResultActions resultActions = mockMvc.perform(
-                MockMvcRequestBuilders.delete("/api/user/delete")
+                MockMvcRequestBuilders.delete(URL + "/delete")
         );
 
         resultActions.andExpect(status().isOk());
@@ -74,7 +75,7 @@ class UserControllerTest {
                 .infoRegistration(any(UserUpdateDto.class));
 
         ResultActions resultActions = mockMvc.perform(
-                MockMvcRequestBuilders.put("/api/user/registration")
+                MockMvcRequestBuilders.put(URL + "/registration")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(new Gson().toJson(userUpdateDto))
 

--- a/src/test/java/com/server/Puzzle/controller/user/UserControllerTest.java
+++ b/src/test/java/com/server/Puzzle/controller/user/UserControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.CharacterEncodingFilter;
 
 import java.util.List;
 
@@ -39,7 +40,10 @@ class UserControllerTest {
 
     @BeforeEach
     public void init() {
-        mockMvc = MockMvcBuilders.standaloneSetup(userController).build();
+        mockMvc = MockMvcBuilders.standaloneSetup(userController)
+                .addFilters(new CharacterEncodingFilter("UTF-8", true))
+                .alwaysDo(print())
+                .build();
     }
 
     @Test
@@ -48,7 +52,7 @@ class UserControllerTest {
         doNothing().when(userService)
                 .logout();
 
-        ResultActions resultActions = mockMvc.perform(
+        final ResultActions resultActions = mockMvc.perform(
                 MockMvcRequestBuilders.delete(URL + "/logout")
         );
 
@@ -60,7 +64,7 @@ class UserControllerTest {
         doNothing().when(userService)
                 .delete();
 
-        ResultActions resultActions = mockMvc.perform(
+        final ResultActions resultActions = mockMvc.perform(
                 MockMvcRequestBuilders.delete(URL + "/delete")
         );
 
@@ -74,19 +78,19 @@ class UserControllerTest {
         doNothing().when(userService)
                 .infoRegistration(any(UserUpdateDto.class));
 
-        ResultActions resultActions = mockMvc.perform(
+        final ResultActions resultActions = mockMvc.perform(
                 MockMvcRequestBuilders.put(URL + "/registration")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(new Gson().toJson(userUpdateDto))
-
-        ).andDo(print());
+                        .characterEncoding("UTF-8")
+        );
 
         resultActions.andExpect(status().isOk());
     }
 
     private UserUpdateDto requestUserUpdateDto() {
         return UserUpdateDto.builder()
-                .name("hyunin")
+                .name("현인")
                 .email("hyunin0102@gmail.com")
                 .imageUrl("https://avatars.githubusercontent.com/u/68847615?v=4")
                 .bio("i am bio")


### PR DESCRIPTION
# 작업 사항

### 프로필 컨트롤러 테스트
프로필 컨트롤러 마다 성공 테스트를 추가하였습니다 

### 검증식 추가
JsonPath 를 통해 response 응답 결과를 검증하는 식을 추가하였습니다.

### 피드백 반영
공통으로 사용하는 url을 클래스 전역에서 사용할 수 있도록 추가하였습니다.