### PR TITLE
잘못된 검증 방식 수정

### DIFF
--- a/src/test/java/com/server/Puzzle/controller/board/BoardControllerTest.java
+++ b/src/test/java/com/server/Puzzle/controller/board/BoardControllerTest.java
@@ -121,14 +121,12 @@ public class BoardControllerTest {
         doReturn(new PageImpl<>(List.of(response))).when(boardService)
                 .getAllPost(any(Pageable.class));
 
-        final String expectByTitle = "$..content[?(@.title == '%s')]";
-
         // when then
         mockMvc.perform(
                     get(BASE_URI.concat("/all"))
                 )
                 .andExpect(status().isOk())
-                .andExpect(jsonPath(expectByTitle,"title").exists());
+                .andExpect(jsonPath("$.content[0].title").value("title"));
     }
 
     @Test
@@ -143,8 +141,8 @@ public class BoardControllerTest {
         mockMvc.perform(
                     get(BASE_URI.concat("/{id}"),1L)
                 )
-                .andExpect(jsonPath("$.id",1).exists())
-                .andExpect(jsonPath("$.title","title").exists());
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.title").value("title"));
     }
 
     @Test
@@ -174,14 +172,12 @@ public class BoardControllerTest {
                         any(Pageable.class)
                 );
 
-        final String expectByTitle = "$..content[?(@.title == '%s')]";
-
         // when, then
         mockMvc.perform(
                     get(BASE_URI.concat("/filter"))
                 )
                 .andExpect(status().isOk())
-                .andExpect(jsonPath(expectByTitle,"title").exists());
+                .andExpect(jsonPath("$.content[0].title").value("title"));
     }
 
     private String postBodyInfo() {


### PR DESCRIPTION
### 제가 한 일은요!!
- BoardControllerTest 의 잘못된 검증방식을 수정했습니다.
"$..content[?(@.title == '%s')]" 이와 같은 정규식을 사용하지 않는 부분까지 두번째 파라미터에 값을 넣어서 검증이 되고 있어서
<img width="392" alt="2022-06-22_10-11-16" src="https://user-images.githubusercontent.com/68670670/174922204-a207b3a0-722c-4f8c-b179-2f8c57bd46de.png">

 .value() 를 사용하는 방식으로 변경(통일)했습니다.