### PR TITLE
프로필 컨트롤러 테스트 검증식 변경

### DIFF
--- a/src/test/java/com/server/Puzzle/controller/profile/ProfileControllerTest.java
+++ b/src/test/java/com/server/Puzzle/controller/profile/ProfileControllerTest.java
@@ -76,10 +76,8 @@ public class ProfileControllerTest {
                         .queryParam("size", "5")
         );
 
-        final String expectByTitle = "$..content[0].[?(@.title == '%s')]";
-
         resultActions.andExpect(status().isOk())
-                .andExpect(jsonPath(expectByTitle, "title").exists());
+                .andExpect(jsonPath("content[0].title").value("title"));
     }
 
     @Test
@@ -92,10 +90,8 @@ public class ProfileControllerTest {
 
         final ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get(URL + "/{githubId}", githubId));
 
-        final String expectByEmail = "$[?(@.email == '%s')]";
-
         resultActions.andExpect(status().isOk())
-                .andExpect(jsonPath(expectByEmail, "hyunin0102@gmail.com").exists());
+                .andExpect(jsonPath("email").value( "hyunin0102@gmail.com"));
     }
 
     @Test


### PR DESCRIPTION
# 작업 사항

## Comments of Commit
### 검증식 방식 변경
- response 값을 검증하는 방식을 jsonPath 표현식이 아닌 `.value()` 키워드를 통해 처리