### PR TITLE
쿼리 개선

### DIFF
--- a/src/main/java/com/server/Puzzle/domain/board/repository/BoardCustomRepository.java
+++ b/src/main/java/com/server/Puzzle/domain/board/repository/BoardCustomRepository.java
@@ -3,6 +3,8 @@ package com.server.Puzzle.domain.board.repository;
 import com.server.Puzzle.domain.board.dto.response.GetPostByTagResponseDto;
 import com.server.Puzzle.domain.board.enumType.Purpose;
 import com.server.Puzzle.domain.board.enumType.Status;
+import com.server.Puzzle.domain.user.domain.User;
+import com.server.Puzzle.domain.user.dto.UserBoardResponse;
 import com.server.Puzzle.global.enumType.Field;
 import com.server.Puzzle.global.enumType.Language;
 import org.springframework.data.domain.Page;
@@ -13,5 +15,5 @@ import java.util.List;
 public interface BoardCustomRepository {
 
     Page<GetPostByTagResponseDto> findBoardByTag(Purpose purpose, List<Field> field, List<Language> language, Status status, Pageable pageable);
-
+    Page<UserBoardResponse> findBoardsByUser(User user, Pageable pageable);
 }

--- a/src/main/java/com/server/Puzzle/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/server/Puzzle/domain/board/repository/BoardRepository.java
@@ -1,15 +1,10 @@
 package com.server.Puzzle.domain.board.repository;
 
 import com.server.Puzzle.domain.board.domain.Board;
-import com.server.Puzzle.domain.user.domain.User;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BoardRepository extends JpaRepository<Board,Long>, BoardCustomRepository {
-
-    Page<Board> findBoardsByUser(User user, Pageable pageable);
 
 }

--- a/src/main/java/com/server/Puzzle/domain/user/domain/User.java
+++ b/src/main/java/com/server/Puzzle/domain/user/domain/User.java
@@ -55,7 +55,7 @@ public class User extends BaseTimeEntity implements UserDetails {
     private List<UserLanguage> userLanguages; // 세부언어
 
     @OneToMany(
-            fetch = FetchType.EAGER,
+            fetch = FetchType.LAZY,
             mappedBy = "user",
             cascade = CascadeType.ALL,
             orphanRemoval = true

--- a/src/main/java/com/server/Puzzle/domain/user/repository/UserCustomRepository.java
+++ b/src/main/java/com/server/Puzzle/domain/user/repository/UserCustomRepository.java
@@ -1,9 +1,10 @@
 package com.server.Puzzle.domain.user.repository;
 
+import com.server.Puzzle.domain.user.domain.User;
 import com.server.Puzzle.domain.user.dto.UserProfileResponse;
 
 public interface UserCustomRepository {
 
     UserProfileResponse findByUser(String githubId);
-
+    User findUserAndRolesByGithubId(String githubId);
 }

--- a/src/main/java/com/server/Puzzle/domain/user/repository/UserCustomRepositoryImpl.java
+++ b/src/main/java/com/server/Puzzle/domain/user/repository/UserCustomRepositoryImpl.java
@@ -37,4 +37,11 @@ public class UserCustomRepositoryImpl implements UserCustomRepository{
                 .build();
     }
 
+    public User findUserAndRolesByGithubId(String githubId) {
+        return jpaQueryFactory.selectFrom(user)
+                .where(user.githubId.eq(githubId))
+                .innerJoin(user.roles).fetchJoin()
+                .fetchOne();
+    }
+
 }

--- a/src/main/java/com/server/Puzzle/domain/user/repository/UserCustomRepositoryImpl.java
+++ b/src/main/java/com/server/Puzzle/domain/user/repository/UserCustomRepositoryImpl.java
@@ -22,6 +22,7 @@ public class UserCustomRepositoryImpl implements UserCustomRepository{
         User user1  = jpaQueryFactory
                 .selectFrom(user)
                 .where(user.githubId.eq(githubId))
+                .innerJoin(user.userLanguages).fetchJoin()
                 .fetchOne();
 
         return UserProfileResponse.builder()

--- a/src/main/java/com/server/Puzzle/domain/user/service/Impl/ProfileServiceImpl.java
+++ b/src/main/java/com/server/Puzzle/domain/user/service/Impl/ProfileServiceImpl.java
@@ -1,11 +1,11 @@
 package com.server.Puzzle.domain.user.service.Impl;
 
-import com.server.Puzzle.domain.board.domain.BoardField;
-import com.server.Puzzle.domain.board.domain.BoardFile;
 import com.server.Puzzle.domain.board.repository.BoardRepository;
 import com.server.Puzzle.domain.user.domain.User;
 import com.server.Puzzle.domain.user.domain.UserLanguage;
-import com.server.Puzzle.domain.user.dto.*;
+import com.server.Puzzle.domain.user.dto.ProfileUpdateDto;
+import com.server.Puzzle.domain.user.dto.UserBoardResponse;
+import com.server.Puzzle.domain.user.dto.UserProfileResponse;
 import com.server.Puzzle.domain.user.repository.UserLanguageRepository;
 import com.server.Puzzle.domain.user.repository.UserRepository;
 import com.server.Puzzle.domain.user.service.ProfileService;
@@ -21,9 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.transaction.Transactional;
-
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.server.Puzzle.global.exception.ErrorCode.USER_NOT_FOUND;
 
@@ -96,24 +94,7 @@ public class ProfileServiceImpl implements ProfileService {
         User user = userRepository.findByGithubId(githubId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
-        return boardRepository.findBoardsByUser(user, pageable)
-                .map(board -> UserBoardResponse.builder()
-                        .boardId(board.getId())
-                        .title(board.getTitle())
-                        .contents(board.getContents())
-                        .introduce(board.getIntroduce())
-                        .date(board.getCreatedDate())
-                        .purpose(board.getPurpose())
-                        .status(board.getStatus())
-                        .thumbnail(
-                                board.getBoardFiles().stream()
-                                        .map(BoardFile::getUrl)
-                                        .findFirst()
-                                        .orElse(null))
-                        .fields(board.getBoardFields().stream()
-                                .map(BoardField::getField)
-                                .collect(Collectors.toList()))
-                        .build());
+        return boardRepository.findBoardsByUser(user, pageable);
     }
 
     private void saveLanguage(List<Language> languages, User user) {

--- a/src/main/java/com/server/Puzzle/global/security/authentication/CustomUserDetailsService.java
+++ b/src/main/java/com/server/Puzzle/global/security/authentication/CustomUserDetailsService.java
@@ -1,14 +1,11 @@
 package com.server.Puzzle.global.security.authentication;
 
 import com.server.Puzzle.domain.user.repository.UserRepository;
-import com.server.Puzzle.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
-
-import static com.server.Puzzle.global.exception.ErrorCode.USER_NOT_FOUND;
 
 @RequiredArgsConstructor
 @Service
@@ -18,8 +15,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String githubId) throws UsernameNotFoundException {
-       return (UserDetails) userRepository.findByGithubId(githubId)
-               .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+       return (UserDetails) userRepository.findUserAndRolesByGithubId(githubId);
     }
     
 }

--- a/src/main/java/com/server/Puzzle/global/util/CurrentUserUtil.java
+++ b/src/main/java/com/server/Puzzle/global/util/CurrentUserUtil.java
@@ -2,13 +2,10 @@ package com.server.Puzzle.global.util;
 
 import com.server.Puzzle.domain.user.domain.User;
 import com.server.Puzzle.domain.user.repository.UserRepository;
-import com.server.Puzzle.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
-
-import static com.server.Puzzle.global.exception.ErrorCode.USER_NOT_FOUND;
 
 @Component
 @RequiredArgsConstructor
@@ -26,8 +23,7 @@ public class CurrentUserUtil {
             name = principal.toString();
         }
 
-        return userRepository.findByGithubId(name)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        return userRepository.findUserAndRolesByGithubId(name);
     }
 
 }

--- a/src/test/java/com/server/Puzzle/exception/board/BoardExceptionTest.java
+++ b/src/test/java/com/server/Puzzle/exception/board/BoardExceptionTest.java
@@ -9,6 +9,9 @@ import com.server.Puzzle.domain.board.repository.BoardRepository;
 import com.server.Puzzle.domain.board.service.BoardService;
 import com.server.Puzzle.domain.user.domain.Roles;
 import com.server.Puzzle.domain.user.domain.User;
+import com.server.Puzzle.domain.user.domain.UserLanguage;
+import com.server.Puzzle.domain.user.repository.RolesRepository;
+import com.server.Puzzle.domain.user.repository.UserLanguageRepository;
 import com.server.Puzzle.domain.user.repository.UserRepository;
 import com.server.Puzzle.global.enumType.Field;
 import com.server.Puzzle.global.enumType.Language;
@@ -23,10 +26,12 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import javax.persistence.EntityManager;
 import javax.transaction.Transactional;
 import java.util.Collections;
 import java.util.List;
 
+import static com.server.Puzzle.global.enumType.Language.SPRINGBOOT;
 import static org.junit.jupiter.api.Assertions.*;
 
 @Transactional
@@ -44,6 +49,15 @@ public class BoardExceptionTest {
 
     @Autowired
     private CurrentUserUtil currentUserUtil;
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private RolesRepository rolesRepository;
+
+    @Autowired
+    private UserLanguageRepository userLanguageRepository;
 
     final PostRequestDto postRequestDto = PostRequestDto.builder()
             .title("title")
@@ -74,6 +88,24 @@ public class BoardExceptionTest {
                 .build();
 
         userRepository.save(user);
+
+        UserLanguage userLanguage = UserLanguage.builder()
+                .id(null)
+                .language(SPRINGBOOT)
+                .user(user)
+                .build();
+
+        Roles roles = Roles.builder()
+                .id(null)
+                .role(Role.ROLE_USER)
+                .user(user)
+                .build();
+
+        userLanguageRepository.save(userLanguage);
+        rolesRepository.save(roles);
+
+        em.flush();
+        em.clear();
 
         UsernamePasswordAuthenticationToken token
                 = new UsernamePasswordAuthenticationToken(user.getGithubId(),"password",List.of(Role.ROLE_USER));

--- a/src/test/java/com/server/Puzzle/exception/user/UserExceptionTest.java
+++ b/src/test/java/com/server/Puzzle/exception/user/UserExceptionTest.java
@@ -1,9 +1,12 @@
 package com.server.Puzzle.exception.user;
 
+import com.server.Puzzle.domain.user.domain.Roles;
 import com.server.Puzzle.domain.user.domain.User;
+import com.server.Puzzle.domain.user.domain.UserLanguage;
+import com.server.Puzzle.domain.user.repository.RolesRepository;
+import com.server.Puzzle.domain.user.repository.UserLanguageRepository;
 import com.server.Puzzle.domain.user.repository.UserRepository;
 import com.server.Puzzle.domain.user.service.TokenService;
-import com.server.Puzzle.global.enumType.Field;
 import com.server.Puzzle.global.enumType.Role;
 import com.server.Puzzle.global.exception.CustomException;
 import com.server.Puzzle.global.exception.ErrorCode;
@@ -26,6 +29,8 @@ import javax.transaction.Transactional;
 import java.util.Date;
 import java.util.List;
 
+import static com.server.Puzzle.global.enumType.Field.BACKEND;
+import static com.server.Puzzle.global.enumType.Language.SPRINGBOOT;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Transactional
@@ -50,6 +55,12 @@ public class UserExceptionTest {
     @Autowired
     CurrentUserUtil currentUserUtil;
 
+    @Autowired
+    UserLanguageRepository userLanguageRepository;
+
+    @Autowired
+    RolesRepository rolesRepository;
+
     @BeforeEach
     void 로그인한_유저확인() {
         //given
@@ -59,14 +70,34 @@ public class UserExceptionTest {
                 .name("홍현인")
                 .profileImageUrl("https://avatars.githubusercontent.com/u/68847615?v=4")
                 .bio("한줄소개")
-                .field(Field.BACKEND)
+                .field(BACKEND)
                 .url("https://github.com/honghyunin")
                 .isFirstVisited(true)
                 .refreshToken("refreshToken")
-                .githubId("honghyunin123")
+                .githubId("honghyunin12")
                 .build();
 
+
         userRepository.save(user);
+
+        UserLanguage userLanguage = UserLanguage.builder()
+                .id(null)
+                .language(SPRINGBOOT)
+                .user(user)
+                .build();
+
+        Roles roles = Roles.builder()
+                .id(null)
+                .role(Role.ROLE_USER)
+                .user(user)
+                .build();
+
+        userLanguageRepository.save(userLanguage);
+        rolesRepository.save(roles);
+
+        em.flush();
+        em.clear();
+
         //when
         UsernamePasswordAuthenticationToken token =
                 new UsernamePasswordAuthenticationToken(user.getGithubId(), "password", List.of(Role.ROLE_USER));

--- a/src/test/java/com/server/Puzzle/service/attend/AttendServiceTest.java
+++ b/src/test/java/com/server/Puzzle/service/attend/AttendServiceTest.java
@@ -12,7 +12,11 @@ import com.server.Puzzle.domain.board.enumType.Purpose;
 import com.server.Puzzle.domain.board.enumType.Status;
 import com.server.Puzzle.domain.board.repository.BoardRepository;
 import com.server.Puzzle.domain.board.service.BoardService;
+import com.server.Puzzle.domain.user.domain.Roles;
 import com.server.Puzzle.domain.user.domain.User;
+import com.server.Puzzle.domain.user.domain.UserLanguage;
+import com.server.Puzzle.domain.user.repository.RolesRepository;
+import com.server.Puzzle.domain.user.repository.UserLanguageRepository;
 import com.server.Puzzle.domain.user.repository.UserRepository;
 import com.server.Puzzle.global.enumType.Field;
 import com.server.Puzzle.global.enumType.Language;
@@ -30,6 +34,7 @@ import javax.persistence.EntityManager;
 import javax.transaction.Transactional;
 import java.util.List;
 
+import static com.server.Puzzle.global.enumType.Language.SPRINGBOOT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -54,6 +59,12 @@ public class AttendServiceTest {
 
     @Autowired
     private CurrentUserUtil currentUserUtil;
+
+    @Autowired
+    private RolesRepository rolesRepository;
+
+    @Autowired
+    private UserLanguageRepository userLanguageRepository;
 
     @Autowired
     private EntityManager em;
@@ -85,6 +96,24 @@ public class AttendServiceTest {
                 .build();
 
         userRepository.save(user);
+
+        UserLanguage userLanguage = UserLanguage.builder()
+                .id(null)
+                .language(SPRINGBOOT)
+                .user(user)
+                .build();
+
+        Roles roles = Roles.builder()
+                .id(null)
+                .role(Role.ROLE_USER)
+                .user(user)
+                .build();
+
+        rolesRepository.save(roles);
+        userLanguageRepository.save(userLanguage);
+
+        em.flush();
+        em.clear();
 
         UsernamePasswordAuthenticationToken token
                 = new UsernamePasswordAuthenticationToken(user.getGithubId(),"password", List.of(Role.ROLE_USER));

--- a/src/test/java/com/server/Puzzle/service/board/BoardServiceTest.java
+++ b/src/test/java/com/server/Puzzle/service/board/BoardServiceTest.java
@@ -9,7 +9,11 @@ import com.server.Puzzle.domain.board.enumType.Purpose;
 import com.server.Puzzle.domain.board.enumType.Status;
 import com.server.Puzzle.domain.board.repository.BoardRepository;
 import com.server.Puzzle.domain.board.service.BoardService;
+import com.server.Puzzle.domain.user.domain.Roles;
 import com.server.Puzzle.domain.user.domain.User;
+import com.server.Puzzle.domain.user.domain.UserLanguage;
+import com.server.Puzzle.domain.user.repository.RolesRepository;
+import com.server.Puzzle.domain.user.repository.UserLanguageRepository;
 import com.server.Puzzle.domain.user.repository.UserRepository;
 import com.server.Puzzle.global.enumType.Field;
 import com.server.Puzzle.global.enumType.Language;
@@ -31,6 +35,7 @@ import javax.transaction.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.server.Puzzle.global.enumType.Language.SPRINGBOOT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -42,6 +47,13 @@ public class BoardServiceTest {
     private UserRepository userRepository;
     @Autowired
     private BoardRepository boardRepository;
+
+    @Autowired
+    RolesRepository rolesRepository;
+
+    @Autowired
+    UserLanguageRepository userLanguageRepository;
+
     @Autowired
     private BoardService boardService;
     @Autowired
@@ -76,6 +88,24 @@ public class BoardServiceTest {
                 .build();
 
         userRepository.save(user);
+
+        UserLanguage userLanguage = UserLanguage.builder()
+                .id(null)
+                .language(SPRINGBOOT)
+                .user(user)
+                .build();
+
+        Roles roles = Roles.builder()
+                .id(null)
+                .role(Role.ROLE_USER)
+                .user(user)
+                .build();
+
+        rolesRepository.save(roles);
+        userLanguageRepository.save(userLanguage);
+
+        em.flush();
+        em.clear();
 
         UsernamePasswordAuthenticationToken token
                 = new UsernamePasswordAuthenticationToken(user.getGithubId(),"password",List.of(Role.ROLE_USER));

--- a/src/test/java/com/server/Puzzle/service/profile/ProfileServiceTest.java
+++ b/src/test/java/com/server/Puzzle/service/profile/ProfileServiceTest.java
@@ -4,11 +4,13 @@ import com.server.Puzzle.domain.board.dto.request.PostRequestDto;
 import com.server.Puzzle.domain.board.enumType.Purpose;
 import com.server.Puzzle.domain.board.enumType.Status;
 import com.server.Puzzle.domain.board.service.BoardService;
+import com.server.Puzzle.domain.user.domain.Roles;
 import com.server.Puzzle.domain.user.domain.User;
 import com.server.Puzzle.domain.user.domain.UserLanguage;
 import com.server.Puzzle.domain.user.dto.ProfileUpdateDto;
 import com.server.Puzzle.domain.user.dto.UserBoardResponse;
 import com.server.Puzzle.domain.user.dto.UserProfileResponse;
+import com.server.Puzzle.domain.user.repository.RolesRepository;
 import com.server.Puzzle.domain.user.repository.UserLanguageRepository;
 import com.server.Puzzle.domain.user.repository.UserRepository;
 import com.server.Puzzle.domain.user.service.ProfileService;
@@ -31,7 +33,6 @@ import javax.transaction.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.server.Puzzle.global.enumType.Language.JAVA;
 import static com.server.Puzzle.global.enumType.Language.SPRINGBOOT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -46,6 +47,12 @@ public class ProfileServiceTest {
 
     @Autowired
     UserRepository userRepository;
+
+    @Autowired
+    RolesRepository rolesRepository;
+
+    @Autowired
+    UserLanguageRepository userLanguageRepository;
 
     @Autowired
     UserLanguageRepository langRepo;
@@ -73,7 +80,25 @@ public class ProfileServiceTest {
 
         userRepository.save(user);
 
-        createUserLanguage(user, JAVA, SPRINGBOOT);
+        UserLanguage userLanguage = UserLanguage.builder()
+                .id(null)
+                .language(SPRINGBOOT)
+                .user(user)
+                .build();
+
+        Roles roles = Roles.builder()
+                .id(null)
+                .role(Role.ROLE_USER)
+                .user(user)
+                .build();
+
+        userLanguageRepository.save(userLanguage);
+        rolesRepository.save(roles);
+
+        em.flush();
+        em.clear();
+
+        createUserLanguage(user, SPRINGBOOT);
         //when
         UsernamePasswordAuthenticationToken token =
                 new UsernamePasswordAuthenticationToken(user.getGithubId(), "password", List.of(Role.ROLE_USER));


### PR DESCRIPTION
# 작업 사항
_이번 PR은 페치 조인을 적용한 쿼리 개선입니다!_
_쿼리 개선은 대부분 N번 나가던 쿼리를 한 방 쿼리로 바꾸거나 쿼리 나가는 횟수를 최소화 시킨 것을 의미합니다._
_사진을 하나만 첨부하여 다른 쿼리 개선도 유사하게 이루어졌다는 부연 설명입니다!!_
## Comments of Commit

### ADD
- __유저와 유저 권한 조회 쿼리 추가__ : 유저 엔티티에서 Roles가 즉시로딩으로 잡혀 있어 유저를 조회할 때마다 User 쿼리 하나, Roles 조회 쿼리 하나 총 두 개의 쿼리가 나갔던 것을 쿼리 개선을 통해 하나로 날아가도록 변경했습니다.
![image](https://user-images.githubusercontent.com/68847615/177075934-d61bf93d-7330-464d-a464-b7d14b226a86.png)


- __페치 조인 추가__ : 묵시적으로 조인하던 쿼리를 명시적으로 페치 조인하여 쿼리를 개선하였습니다.
- __유저 작성글 조회 쿼리 추가__ : 페치 조인을 적용하여 쿼리 개선하였습니다.
### UPD

- __유저 권한 지연로딩으로 변경__ : 유저 권한이 필요할 때만 조회하기 위해 지연로딩으로 변경하였습니다.
- __변경에 따른 작업 사항__ : 개선되거나 추가된 쿼리를 사용하기 위해 추가된 작업 사항 들입니다.